### PR TITLE
Auto-merge all Dependabot updates including major

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,10 +16,7 @@ jobs:
       - uses: dependabot/fetch-metadata@v2
         id: metadata
 
-      - name: Enable auto-merge for patch and minor updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+      - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Removes the semver filter so Dependabot PRs with major version bumps also auto-merge. CI will catch any breaking changes.