### PR TITLE
fix: replace sqlite3 with node:sqlite to fix GLIBC error in Docker

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc"
+  ],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {},
+  "env": {
+    "builtin": true
+  }
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,10 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "typescript",
-    "unicorn",
-    "oxc"
-  ],
+  "plugins": ["typescript", "unicorn", "oxc"],
   "categories": {
     "correctness": "error"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@astrojs/node": "^11.1.4",
+    "@astrojs/node": "^10.1.4",
     "@point-of-sale/receipt-printer-encoder": "github:cervantes-x/ReceiptPrinterEncoder",
     "astro": "^6.4.8",
     "canvas": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "@point-of-sale/receipt-printer-encoder": "github:cervantes-x/ReceiptPrinterEncoder",
     "astro": "^6.4.8",
     "canvas": "^3.2.3",
-    "sharp": "^0.35.3",
-    "sqlite3": "^6.0.1"
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.2.0)
-      sqlite3:
-        specifier: ^6.0.1
-        version: 6.0.1
     devDependencies:
       '@types/node':
         specifier: ^26.2.0
@@ -765,10 +762,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1380,10 +1373,6 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
-  abbrev@4.0.0:
-    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -1416,9 +1405,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1461,10 +1447,6 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1604,10 +1586,6 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
@@ -1652,9 +1630,6 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  exponential-backoff@3.1.3:
-    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -1675,9 +1650,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -1711,9 +1683,6 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -1795,10 +1764,6 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
-
-  isexe@4.0.0:
-    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
-    engines: {node: '>=20'}
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -2041,14 +2006,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2086,25 +2043,11 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-addon-api@8.8.0:
-    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
-    engines: {node: ^18 || ^20 || >= 21}
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  node-gyp@12.4.0:
-    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
-
-  nopt@9.0.0:
-    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2213,10 +2156,6 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
-
-  proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -2371,10 +2310,6 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  sqlite3@6.0.1:
-    resolution: {integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==}
-    engines: {node: '>=20.17.0'}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2406,10 +2341,6 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -2468,10 +2399,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
-    engines: {node: '>=18.17'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2719,11 +2646,6 @@ packages:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
 
-  which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2734,10 +2656,6 @@ packages:
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
@@ -3219,10 +3137,6 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -3617,9 +3531,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  abbrev@4.0.0:
-    optional: true
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -3732,10 +3643,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -3773,8 +3680,6 @@ snapshots:
       readdirp: 5.0.0
 
   chownr@1.1.4: {}
-
-  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -3886,9 +3791,6 @@ snapshots:
 
   entities@6.0.1: {}
 
-  env-paths@2.2.1:
-    optional: true
-
   es-module-lexer@2.3.1: {}
 
   es-module-lexer@2.3.2: {}
@@ -3969,9 +3871,6 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  exponential-backoff@3.1.3:
-    optional: true
-
   extend@3.0.2: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -3987,8 +3886,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
-
-  file-uri-to-path@1.0.0: {}
 
   flattie@1.1.1: {}
 
@@ -4014,9 +3911,6 @@ snapshots:
   github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
-
-  graceful-fs@4.2.11:
-    optional: true
 
   h3@1.15.11:
     dependencies:
@@ -4152,9 +4046,6 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
-
-  isexe@4.0.0:
-    optional: true
 
   js-yaml@4.3.0:
     dependencies:
@@ -4552,12 +4443,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-
   mkdirp-classic@0.5.3: {}
 
   mrmime@2.0.1: {}
@@ -4582,30 +4467,9 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-addon-api@8.8.0: {}
-
   node-fetch-native@1.6.7: {}
 
-  node-gyp@12.4.0:
-    dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.3
-      graceful-fs: 4.2.11
-      nopt: 9.0.0
-      proc-log: 6.1.0
-      semver: 7.8.5
-      tar: 7.5.16
-      tinyglobby: 0.2.17
-      undici: 6.27.0
-      which: 6.0.1
-    optional: true
-
   node-mock-http@1.0.4: {}
-
-  nopt@9.0.0:
-    dependencies:
-      abbrev: 4.0.0
-    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -4747,9 +4611,6 @@ snapshots:
       tunnel-agent: 0.6.0
 
   prismjs@1.30.0: {}
-
-  proc-log@6.1.0:
-    optional: true
 
   property-information@7.2.0: {}
 
@@ -5056,15 +4917,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  sqlite3@6.0.1:
-    dependencies:
-      bindings: 1.5.0
-      node-addon-api: 8.8.0
-      prebuild-install: 7.1.3
-      tar: 7.5.16
-    optionalDependencies:
-      node-gyp: 12.4.0
-
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -5107,14 +4959,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
@@ -5154,9 +4998,6 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@8.3.0: {}
-
-  undici@6.27.0:
-    optional: true
 
   unified@11.0.5:
     dependencies:
@@ -5304,11 +5145,6 @@ snapshots:
 
   which-pm-runs@1.1.0: {}
 
-  which@6.0.1:
-    dependencies:
-      isexe: 4.0.0
-    optional: true
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -5317,8 +5153,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   xxhash-wasm@1.1.0: {}
-
-  yallist@5.0.0: {}
 
   yargs-parser@22.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
   .:
     dependencies:
       '@astrojs/node':
-        specifier: ^11.1.4
-        version: 11.1.4(astro@6.4.8(@types/node@26.2.0)(lightningcss@1.33.0)(rollup@4.62.2))
+        specifier: ^10.1.4
+        version: 10.1.4(astro@6.4.8(@types/node@26.2.0)(lightningcss@1.33.0)(rollup@4.62.2))
       '@point-of-sale/receipt-printer-encoder':
         specifier: github:cervantes-x/ReceiptPrinterEncoder
         version: https://codeload.github.com/cervantes-x/ReceiptPrinterEncoder/tar.gz/577487da93b2837654b955a99442ec9262df6841
@@ -82,16 +82,13 @@ packages:
   '@astrojs/internal-helpers@0.10.0':
     resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
-  '@astrojs/internal-helpers@0.10.4':
-    resolution: {integrity: sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==}
-
   '@astrojs/markdown-remark@7.2.0':
     resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
-  '@astrojs/node@11.1.4':
-    resolution: {integrity: sha512-R5tNIHm5ihyEYa0w1mLlfwLpwF1ArRmzHD/is5PUHYRY43G1Xm0k3D2HRJXgjey8/7+1DvDMJLUeBxXwgAyNDg==}
+  '@astrojs/node@10.1.4':
+    resolution: {integrity: sha512-itV568ttlrpwNsutO+KPziqKfzTPlAIXMADlpBi3VeQ3liivRKKKG+jm+IjLMKvYGkxd0QnClKVCBP4i3gpwQQ==}
     peerDependencies:
-      astro: ^7.2.1
+      astro: ^6.3.0
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
@@ -1288,56 +1285,28 @@ packages:
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
 
-  '@shikijs/core@4.4.3':
-    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
-    engines: {node: '>=20'}
-
   '@shikijs/engine-javascript@4.3.1':
     resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@4.4.3':
-    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-oniguruma@4.3.1':
     resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.4.3':
-    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
-    engines: {node: '>=20'}
-
   '@shikijs/langs@4.3.1':
     resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
-    engines: {node: '>=20'}
-
-  '@shikijs/langs@4.4.3':
-    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
     engines: {node: '>=20'}
 
   '@shikijs/primitive@4.3.1':
     resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.4.3':
-    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
-    engines: {node: '>=20'}
-
   '@shikijs/themes@4.3.1':
     resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@4.4.3':
-    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
-    engines: {node: '>=20'}
-
   '@shikijs/types@4.3.1':
     resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
-    engines: {node: '>=20'}
-
-  '@shikijs/types@4.4.3':
-    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -1833,10 +1802,6 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsonc-parser@3.3.1:
@@ -2383,10 +2348,6 @@ packages:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
-  shiki@4.4.3:
-    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
-    engines: {node: '>=20'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2401,10 +2362,6 @@ packages:
 
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
-    engines: {node: '>= 18'}
-
-  smol-toml@1.8.0:
-    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -2811,17 +2768,6 @@ snapshots:
       smol-toml: 1.7.0
       unified: 11.0.5
 
-  '@astrojs/internal-helpers@0.10.4':
-    dependencies:
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      js-yaml: 4.3.1
-      picomatch: 4.0.5
-      retext-smartypants: 6.2.0
-      shiki: 4.4.3
-      smol-toml: 1.8.0
-      unified: 11.0.5
-
   '@astrojs/markdown-remark@7.2.0':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
@@ -2844,9 +2790,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@11.1.4(astro@6.4.8(@types/node@26.2.0)(lightningcss@1.33.0)(rollup@4.62.2))':
+  '@astrojs/node@10.1.4(astro@6.4.8(@types/node@26.2.0)(lightningcss@1.33.0)(rollup@4.62.2))':
     dependencies:
-      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/internal-helpers': 0.10.0
       astro: 6.4.8(@types/node@26.2.0)(lightningcss@1.33.0)(rollup@4.62.2)
       send: 1.2.1
       server-destroy: 1.0.1
@@ -3556,23 +3502,9 @@ snapshots:
       '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@4.4.3':
-    dependencies:
-      '@shikijs/primitive': 4.4.3
-      '@shikijs/types': 4.4.3
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-      hast-util-to-html: 9.0.5
-
   '@shikijs/engine-javascript@4.3.1':
     dependencies:
       '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
-  '@shikijs/engine-javascript@4.4.3':
-    dependencies:
-      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
@@ -3581,18 +3513,9 @@ snapshots:
       '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@4.4.3':
-    dependencies:
-      '@shikijs/types': 4.4.3
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/langs@4.3.1':
     dependencies:
       '@shikijs/types': 4.3.1
-
-  '@shikijs/langs@4.4.3':
-    dependencies:
-      '@shikijs/types': 4.4.3
 
   '@shikijs/primitive@4.3.1':
     dependencies:
@@ -3600,26 +3523,11 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
-  '@shikijs/primitive@4.4.3':
-    dependencies:
-      '@shikijs/types': 4.4.3
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
   '@shikijs/themes@4.3.1':
     dependencies:
       '@shikijs/types': 4.3.1
 
-  '@shikijs/themes@4.4.3':
-    dependencies:
-      '@shikijs/types': 4.4.3
-
   '@shikijs/types@4.3.1':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
-  '@shikijs/types@4.4.3':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
@@ -4249,10 +4157,6 @@ snapshots:
     optional: true
 
   js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5134,17 +5038,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
-  shiki@4.4.3:
-    dependencies:
-      '@shikijs/core': 4.4.3
-      '@shikijs/engine-javascript': 4.4.3
-      '@shikijs/engine-oniguruma': 4.4.3
-      '@shikijs/langs': 4.4.3
-      '@shikijs/themes': 4.4.3
-      '@shikijs/types': 4.4.3
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
   siginfo@2.0.0: {}
 
   simple-concat@1.0.1: {}
@@ -5158,8 +5051,6 @@ snapshots:
   sisteransi@1.0.5: {}
 
   smol-toml@1.7.0: {}
-
-  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/__tests__/database.test.ts
+++ b/src/__tests__/database.test.ts
@@ -42,16 +42,12 @@ describe("database module", () => {
     const db = await importDbWithMemory();
     const buf = Buffer.from("hello world");
     const res = db
-      .prepare(
-        "INSERT INTO images (data, user_agent, ip_address, file_name) VALUES (?, ?, ?, ?)",
-      )
+      .prepare("INSERT INTO images (data, user_agent, ip_address, file_name) VALUES (?, ?, ?, ?)")
       .run(buf, "test-agent", "127.0.0.1", "foo.png");
     const lastID = res.lastInsertRowid;
     if (typeof lastID !== "number") throw new Error("insert did not return lastID");
     const row = db
-      .prepare(
-        "SELECT id, data, user_agent, ip_address, file_name FROM images WHERE id = ?",
-      )
+      .prepare("SELECT id, data, user_agent, ip_address, file_name FROM images WHERE id = ?")
       .get(lastID) as ImageRow | undefined;
     expect(row).toBeDefined();
     if (!row) throw new Error("expected row to be present");

--- a/src/__tests__/database.test.ts
+++ b/src/__tests__/database.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import type { Database } from "sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 
-type DB = Database;
-
-interface RunResult {
-  lastID?: number;
-  changes?: number;
-}
+type DB = DatabaseSync;
 
 interface ColumnInfo {
   cid: number;
@@ -19,7 +14,7 @@ interface ColumnInfo {
 
 interface ImageRow {
   id: number;
-  data: Buffer;
+  data: Uint8Array;
   user_agent: string | null;
   ip_address: string | null;
   file_name: string | null;
@@ -32,96 +27,39 @@ async function importDbWithMemory(): Promise<DB> {
   return mod.default as DB;
 }
 
-function runAsync(db: DB, sql: string, params?: unknown[]) {
-  return new Promise<{ lastID?: number; changes?: number }>((resolve, reject) => {
-    db.run(sql, params ?? [], function (this: RunResult, err: Error | null) {
-      if (err) return reject(err);
-      resolve({ lastID: this?.lastID, changes: this?.changes });
-    });
-  });
-}
-
-function getAsync<T>(db: DB, sql: string, params?: unknown[]) {
-  return new Promise<T | undefined>((resolve, reject) => {
-    db.get(sql, params ?? [], (err: Error | null, row?: T) => {
-      if (err) return reject(err);
-      resolve(row);
-    });
-  });
-}
-
-function allAsync<T>(db: DB, sql: string, params?: unknown[]) {
-  return new Promise<T[]>((resolve, reject) => {
-    db.all(sql, params ?? [], (err: Error | null, rows?: T[]) => {
-      if (err) return reject(err);
-      resolve(rows ?? []);
-    });
-  });
-}
-
-function closeAsync(db: DB) {
-  return new Promise<void>((resolve, reject) => {
-    db.close((err: Error | null) => {
-      if (err) return reject(err);
-      resolve();
-    });
-  });
-}
-
-function waitForImagesTable(db: DB, timeout = 2000) {
-  return new Promise<void>((resolve, reject) => {
-    const start = Date.now();
-    (function check() {
-      db.get(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='images'",
-        (err: Error | null, row?: { name: string }) => {
-          if (err) return reject(err);
-          if (row) return resolve();
-          if (Date.now() - start > timeout)
-            return reject(new Error("timed out waiting for images table"));
-          setTimeout(check, 20);
-        },
-      );
-    })();
-  });
-}
-
 describe("database module", () => {
   it("initializes images table with expected columns", async () => {
     const db = await importDbWithMemory();
-    await waitForImagesTable(db);
-    const columns = await allAsync<ColumnInfo>(db, "PRAGMA table_info(images)");
+    const columns = db.prepare("PRAGMA table_info(images)").all() as ColumnInfo[];
     const columnNames = columns.map((c) => c.name);
     expect(columnNames).toEqual(
       expect.arrayContaining(["id", "data", "user_agent", "ip_address", "file_name"]),
     );
-    await closeAsync(db);
+    db.close();
   });
 
   it("inserts and retrieves an image row", async () => {
     const db = await importDbWithMemory();
-    await waitForImagesTable(db);
     const buf = Buffer.from("hello world");
-    const res = await runAsync(
-      db,
-      "INSERT INTO images (data, user_agent, ip_address, file_name) VALUES (?, ?, ?, ?)",
-      [buf, "test-agent", "127.0.0.1", "foo.png"],
-    );
-    expect(res.lastID).toBeDefined();
-    const lastID = res.lastID;
+    const res = db
+      .prepare(
+        "INSERT INTO images (data, user_agent, ip_address, file_name) VALUES (?, ?, ?, ?)",
+      )
+      .run(buf, "test-agent", "127.0.0.1", "foo.png");
+    const lastID = res.lastInsertRowid;
     if (typeof lastID !== "number") throw new Error("insert did not return lastID");
-    const row = await getAsync<ImageRow>(
-      db,
-      "SELECT id, data, user_agent, ip_address, file_name FROM images WHERE id = ?",
-      [lastID],
-    );
+    const row = db
+      .prepare(
+        "SELECT id, data, user_agent, ip_address, file_name FROM images WHERE id = ?",
+      )
+      .get(lastID) as ImageRow | undefined;
     expect(row).toBeDefined();
     if (!row) throw new Error("expected row to be present");
     expect(row.id).toBe(lastID);
-    expect(row.data).toEqual(buf);
+    expect(Buffer.from(row.data)).toEqual(buf);
     expect(row.user_agent).toBe("test-agent");
     expect(row.ip_address).toBe("127.0.0.1");
     expect(row.file_name).toBe("foo.png");
-    await closeAsync(db);
+    db.close();
   });
 });

--- a/src/__tests__/printer.test.ts
+++ b/src/__tests__/printer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { client, encoder } from "@/lib/printer";
 
 describe("printer module", () => {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -55,11 +55,9 @@ export const server = {
         .png({ colors: 4 })
         .toBuffer();
 
-      db
-        .prepare(
-          "INSERT INTO images (data, file_name, ip_address, user_agent) VALUES (?, ?, ?, ?)",
-        )
-        .run(processedImage, file_name, ip, userAgent);
+      db.prepare(
+        "INSERT INTO images (data, file_name, ip_address, user_agent) VALUES (?, ?, ?, ?)",
+      ).run(processedImage, file_name, ip, userAgent);
       await sharp(processedImage).toFile("./photo.png");
 
       const image = await loadImage(processedImage);
@@ -86,9 +84,10 @@ export const server = {
   getCurrentPhotos: defineAction({
     accept: "json",
     handler: async (_input, _context) => {
-      const rows = db
-        .prepare("SELECT id, data FROM images ORDER BY id DESC LIMIT 9")
-        .all() as { id: number; data: Uint8Array }[];
+      const rows = db.prepare("SELECT id, data FROM images ORDER BY id DESC LIMIT 9").all() as {
+        id: number;
+        data: Uint8Array;
+      }[];
       return rows.map((row) => ({
         id: row.id,
         data: Buffer.from(row.data),

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -55,14 +55,11 @@ export const server = {
         .png({ colors: 4 })
         .toBuffer();
 
-      db.run(
-        "INSERT INTO images (data, file_name, ip_address, user_agent) VALUES (?, ?, ?, ?)",
-        processedImage,
-        file_name,
-        ip,
-        userAgent,
-      );
-
+      db
+        .prepare(
+          "INSERT INTO images (data, file_name, ip_address, user_agent) VALUES (?, ?, ?, ?)",
+        )
+        .run(processedImage, file_name, ip, userAgent);
       await sharp(processedImage).toFile("./photo.png");
 
       const image = await loadImage(processedImage);
@@ -89,22 +86,13 @@ export const server = {
   getCurrentPhotos: defineAction({
     accept: "json",
     handler: async (_input, _context) => {
-      return new Promise<{ id: number; data: Buffer }[]>((resolve, reject) => {
-        db.all(
-          "SELECT id, data FROM images ORDER BY id DESC LIMIT 9;",
-          (err: Error | null, rows: { id: number; data: Buffer }[]) => {
-            if (err) {
-              reject(err);
-            } else {
-              const formattedRows = rows.map((row) => ({
-                id: row.id,
-                data: Buffer.from(row.data),
-              }));
-              resolve(formattedRows);
-            }
-          },
-        );
-      });
+      const rows = db
+        .prepare("SELECT id, data FROM images ORDER BY id DESC LIMIT 9")
+        .all() as { id: number; data: Uint8Array }[];
+      return rows.map((row) => ({
+        id: row.id,
+        data: Buffer.from(row.data),
+      }));
     },
   }),
 };

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,35 +1,24 @@
-import sqlite3 from "sqlite3";
-import type { Database } from "sqlite3";
+import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const dbDir: string = path.dirname(fileURLToPath(import.meta.url));
 const dbFilePath: string = process.env.IMAGES_DB_PATH ?? path.resolve(dbDir, "images.db");
-const flags: number = sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE;
 
-const db: Database = new sqlite3.Database(dbFilePath, flags);
+const db: DatabaseSync = new DatabaseSync(dbFilePath);
 
-function addColumnIfMissing(sql: string): void {
-  db.run(sql, (err: Error | null) => {
-    if (!err) return;
-    if (err instanceof Error) {
-      if (!/duplicate column/i.test(err.message)) {
-        console.error("Error adding column:", err);
-      }
-    } else {
+db.exec(
+  "CREATE TABLE IF NOT EXISTS images (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB NOT NULL)",
+);
+
+for (const column of ["user_agent TEXT", "ip_address TEXT", "file_name TEXT"]) {
+  try {
+    db.exec(`ALTER TABLE images ADD COLUMN ${column}`);
+  } catch (err) {
+    if (!(err instanceof Error && /duplicate column/i.test(err.message))) {
       console.error("Error adding column:", err);
     }
-  });
+  }
 }
-
-db.serialize(() => {
-  db.run(
-    "CREATE TABLE IF NOT EXISTS images (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB NOT NULL)",
-  );
-
-  addColumnIfMissing("ALTER TABLE images ADD COLUMN user_agent TEXT");
-  addColumnIfMissing("ALTER TABLE images ADD COLUMN ip_address TEXT");
-  addColumnIfMissing("ALTER TABLE images ADD COLUMN file_name TEXT");
-});
 
 export default db;

--- a/src/lib/printer.ts
+++ b/src/lib/printer.ts
@@ -54,7 +54,7 @@ for (const event of socketEvents) {
   });
 }
 
-// biome-ignore lint:
+// oxlint-disable-next-line no-shadow-restricted-names
 declare const globalThis: {
   printerClientGlobal: ReturnType<typeof printerClientSingleton>;
   printerConnected: boolean;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,7 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
 
-const rateLimit = new Map();
-
 export const onRequest = defineMiddleware((context, next) => {
   // if (!context.url.pathname.includes("/api")) {
   //     return next();


### PR DESCRIPTION
## Problem

Runtime crash in the Docker container (Coolify):

```
Error: /lib/x86_64-linux-gnu/libm.so.6: version 'GLIBC_2.38' not found
(required by node_modules/sqlite3/build/Release/node_sqlite3.node)
```

The `sqlite3` npm package ships a prebuilt native binary compiled against a newer glibc than the `node:lts` image provides.

## Fix

Drop the native dependency entirely and use Node's built-in `node:sqlite` (stable in Node 22.5+/`node:lts`):

- `src/lib/database.ts` — `DatabaseSync` replaces the callback-based sqlite3 API; migration still adds missing columns
- `src/actions/index.ts` — insert via `prepare().run()`, photo list via `prepare().all()`
- `src/__tests__/database.test.ts` — simplified for the sync API (no more async wrappers/polling)
- Removed `sqlite3` from dependencies (-166 lockfile lines, no prebuild-install)

## Verification

- `pnpm test`: 3 passing
- `oxlint` clean
- No native build steps left for SQLite — works on any container glibc