### PR TITLE
chore: slim production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,31 @@
-FROM node:lts AS base
+FROM node:lts-slim AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-RUN corepack install -g pnpm@10.33.2
+RUN corepack enable && corepack install -g pnpm@10.33.2
 ENV COREPACK_INTEGRITY_KEYS=0
 
-COPY . /app
 WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --prod --frozen-lockfile
 
 FROM base AS build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+COPY . .
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM base
+FROM node:lts-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
 
-COPY --from=prod-deps /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
 
 ENV HOST=0.0.0.0
 ENV PORT=4321
@@ -28,4 +34,4 @@ EXPOSE 4321
 LABEL org.opencontainers.image.source=https://github.com/drc/astro-thermal
 LABEL org.opencontainers.image.description="Astro API to interface with a Rongata receipt printer"
 
-CMD ["pnpm", "start"]
+CMD ["node", "dist/server/entry.mjs"]


### PR DESCRIPTION
## Summary
- switch production image from `node:lts` to `node:lts-slim`
- use a dedicated runtime stage containing only production dependencies and `dist`
- run the server directly with Node instead of requiring pnpm at runtime
- install `libexpat1` for the `canvas` native runtime

## Verification
- Docker build passed
- container startup passed
- HTTP smoke test returned 200
- canvas loaded successfully
- image size reduced from approximately 1.35 GB to 445 MB